### PR TITLE
Add dependencies for segment.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ dependencies = [
     "monai",
     "pytorch-lightning",
     "torch",
+    "imageio",
+    "scipy",
+    "mrcfile"
 ]
 
 # extras


### PR DESCRIPTION
Currently inference with segment.py requires a few extra requirements, which should be part of the dependencies declared for pip installing.