### PR TITLE
docs template

### DIFF
--- a/.github/workflows/build-and-deploy-docs.yml
+++ b/.github/workflows/build-and-deploy-docs.yml
@@ -1,0 +1,38 @@
+name: docs
+
+on:
+  push:
+    branches:
+      - main
+
+# This job installs dependencies, builds the book, and pushes it to
+# the `gh-pages` branch of the same repository.
+jobs:
+  deploy-book:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          # pip install -e .
+          pip install mkdocs mkdocs-material mkdocstrings[python]
+
+      # Build the book
+      - name: Build the book
+        run: |
+          mkdocs build
+
+      # Push the site to github-pages
+      - name: GitHub Pages action
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          publish_dir: ./site
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,10 @@
+# Overview
+
+This repo is a simple documentation template for projects in the teamtomo organisation.
+
+Documentation is built from simple markdown files using 
+*[mkdocs-material](https://squidfunk.github.io/mkdocs-material/)*.
+
+The source files for this site can be found at 
+[*teamtomo/docs-template*](https://github.com/teamtomo/docs-template).
+

--- a/docs/page.md
+++ b/docs/page.md
@@ -1,0 +1,3 @@
+# Simple Page
+
+here is a documentation page! Things are written in markdown

--- a/docs/section/another_page.md
+++ b/docs/section/another_page.md
@@ -1,0 +1,3 @@
+# Another Page
+
+this is another page!

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,52 @@
+site_name: teamtomo docs template
+site_url: https://teamtomo.org/docs-template
+site_author: teamtomo
+site_description: >-
+  Documentation for docs-template
+repo_name: teamtomo/docs-template
+repo_url: https://github.com/teamtomo/docs-template
+edit_uri: edit/main/docs/
+
+copyright: Copyright &copy; 2022 - 2022 teamtomo
+
+
+# Custom navigation can be specified
+#nav:
+#  - Overview: index.md
+#  - Section:
+#      - Title: directory/file.md
+
+theme:
+  icon:
+    logo: material/cube-outline
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: blue
+      accent: blue
+
+  features:
+    - navigation.instant
+    - search.highlight
+    - search.suggest
+    - content.tabs.link
+
+markdown_extensions:
+  - admonition
+  - tables
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight
+  - pymdownx.tabbed:
+      alternate_style: true
+  - attr_list
+  - pymdownx.emoji:
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
+  - md_in_html
+  - pymdownx.arithmatex:
+      generic: true
+
+plugins:
+  - search

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
-site_name: teamtomo docs template
-site_url: https://teamtomo.org/docs-template
+site_name: membrain-seg
+site_url: https://teamtomo.org/membrain-seg
 site_author: teamtomo
 site_description: >-
-  Documentation for docs-template
+  Membrane segmentation in cryo-electron tomography data.
 repo_name: teamtomo/docs-template
 repo_url: https://github.com/teamtomo/docs-template
 edit_uri: edit/main/docs/
@@ -10,7 +10,7 @@ edit_uri: edit/main/docs/
 copyright: Copyright &copy; 2022 - 2022 teamtomo
 
 
-# Custom navigation can be specified
+# Custom navigation can be specified but isn't strictly necessary
 #nav:
 #  - Overview: index.md
 #  - Section:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = [
     "pytest",
     "rich",
     "ruff",
+    "mkdocs-material",
 ]
 
 [project.urls]


### PR DESCRIPTION
Hey @LorenzLamm 

So great to see you pushing this again - in this PR you have all that you need to work on documentation, I'm using [mkdocs-material](https://squidfunk.github.io/mkdocs-material/) 

basics:
- pip install mkdocs-material
- write markdown in docs folder
- if you add images, put them in comments on a github issue and reference the URL of that uploaded image
- `mkdocs serve` in the repo root for local preview
- there is a github action for deployment to GitHub pages which will make the site available at teamtomo.org/membrain-seg

Please feel free to merge this PR and iterate, editing an existing thing is always much easier than starting from scratch :)