### PR TITLE
Connected components

### DIFF
--- a/docs/Usage/Segmentation.md
+++ b/docs/Usage/Segmentation.md
@@ -40,11 +40,9 @@ membrain segment
 ```
 will display the segmentation command line interface and show available options.
 
-
 <p align="center" width="100%">
     <img width="50%" src="https://user-images.githubusercontent.com/34575029/250504257-611ea864-48c5-4424-9bc8-7b30bcfbb39b.png">
 </p>
-
 
 For example, for the prediction, you only need to type
 
@@ -59,6 +57,31 @@ the `--out_folder` argument:
 ```shell
 membrain segment --tomogram-path <path-to-your-tomo> --ckpt-path <path-to-your-model> --out-folder <your-preferred-folder>
 ```
+
+It is now also possible to assign different labels to different membrane instances via computing connected components and also remove small connected components:
+```shell
+membrain segment --tomogram-path <path-to-your-tomo> --ckpt-path <path-to-your-model> --store-connected-components --connected-component-thres 50
+```
+
+
+
+### more membrain segment arguments:
+**--tomogram-path**: TEXT Path to the tomogram to be segmented [default: None] 
+
+**--ckpt-path** TEXT Path to the pre-trained model checkpoint that should be used. [default: None] 
+
+**--out-folder** TEXT Path to the folder where segmentations should be stored. [default: ./predictions]
+
+**--store-probabilities / --no-store-probabilities**: Should probability maps be output in addition to segmentations? [default: no-store-probabilities]
+
+**--store-connected-components / no-store-connected-components**: Should connected components of the segmentation be computed? [default: no-store-connected-components]  
+
+**--connected-component-thres**: Threshold for connected components. Components smaller than this will be removed from the segmentation. [default: None]
+
+**--sliding-window-size** INTEGER Sliding window size used for inference. Smaller values than 160 consume less GPU, but also lead to worse segmentation results! [default: 160] 
+
+**--help**                                                                      Show this message and exit.     
+
 
 ### Note: 
 MemBrain-seg automatically detects a CUDA-enabled GPU, if available, and will execute the segmentation on it. Using a GPU device is highly recommended to accelerate the segmentation process.

--- a/docs/Usage/Segmentation.md
+++ b/docs/Usage/Segmentation.md
@@ -60,7 +60,7 @@ membrain segment --tomogram-path <path-to-your-tomo> --ckpt-path <path-to-your-m
 
 It is now also possible to assign different labels to different membrane instances via computing connected components and also remove small connected components:
 ```shell
-membrain segment --tomogram-path <path-to-your-tomo> --ckpt-path <path-to-your-model> --store-connected-components --connected-component-thres 50
+membrain segment --tomogram-path <path-to-your-tomo> --ckpt-path <path-to-your-model> --store-connected-components
 ```
 
 You can also compute the connected components [after you have segmented your tomogram](#connected-components).
@@ -99,6 +99,8 @@ If you have segmented your tomograms already, but would still like to extract th
 membrain components --segmentation-path <path-to-your-segmentation> --connected-component-thres 50 --out-folder <folder-to-store-components>
 ```
 
+### Note: 
+Computing the connected components, and particularly also removing the small components can be quite compute intensive and take a while.
 
 
 

--- a/docs/Usage/Segmentation.md
+++ b/docs/Usage/Segmentation.md
@@ -63,6 +63,7 @@ It is now also possible to assign different labels to different membrane instanc
 membrain segment --tomogram-path <path-to-your-tomo> --ckpt-path <path-to-your-model> --store-connected-components --connected-component-thres 50
 ```
 
+You can also compute the connected components [after you have segmented your tomogram](#connected-components).
 
 
 ### more membrain segment arguments:
@@ -80,7 +81,7 @@ membrain segment --tomogram-path <path-to-your-tomo> --ckpt-path <path-to-your-m
 
 **--sliding-window-size** INTEGER Sliding window size used for inference. Smaller values than 160 consume less GPU, but also lead to worse segmentation results! [default: 160] 
 
-**--help**                                                                      Show this message and exit.     
+**--help** Show this message and exit.     
 
 
 ### Note: 
@@ -91,6 +92,15 @@ Running MemBrain-seg on a GPU requires at least roughly 8GB of GPU space.
 
 ### Emergency tip:
 In case you don't have enough GPU space, you can also try adjusting the `--sliding-window-size` parameter. By default, it is set to 160. Smaller values will require less GPU space, but also lead to worse segmentation results!
+
+## Connected components
+If you have segmented your tomograms already, but would still like to extract the connected components of the segmentation, you don't need to re-do the segmentation, but can simply use the following command:
+```shell
+membrain components --segmentation-path <path-to-your-segmentation> --connected-component-thres 50 --out-folder <folder-to-store-components>
+```
+
+
+
 
 ## Post-Processing
 If you have pre-processed your tomogram using pixel size matching, you may want to [rescale](./Preprocessing.md#pixel-size-matching) your 

--- a/src/membrain_seg/annotations/extract_patches.py
+++ b/src/membrain_seg/annotations/extract_patches.py
@@ -165,8 +165,8 @@ def extract_patches(
     make_directory_if_not_exists(out_folder_raw)
     make_directory_if_not_exists(out_folder_lab)
 
-    tomo = load_tomogram(tomo_path)
-    labels = load_tomogram(seg_path)
+    tomo = load_tomogram(tomo_path).data
+    labels = load_tomogram(seg_path).data
 
     for patch_nr, cur_coords in enumerate(coords):
         patch_nr, out_file_patch, out_file_patch_label = get_out_files_and_patch_number(

--- a/src/membrain_seg/segmentation/cli/segment_cli.py
+++ b/src/membrain_seg/segmentation/cli/segment_cli.py
@@ -85,12 +85,13 @@ def components(
     membrain components --tomogram-path <path-to-your-tomo>
     --connected-component-thres 5
     """
-    data, header = load_tomogram(segmentation_path, return_header=True)
+    segmentation = load_tomogram(segmentation_path)
     conn_comps = _connected_components(
-        binary_seg=data, size_thres=connected_component_thres
+        binary_seg=segmentation.data, size_thres=connected_component_thres
     )
+    segmentation.data = conn_comps
     out_file = os.path.join(
         out_folder,
         os.path.splitext(os.path.basename(segmentation_path))[0] + "_components.mrc",
     )
-    store_tomogram(filename=out_file, tomogram=conn_comps, header=header)
+    store_tomogram(filename=out_file, tomogram=segmentation)

--- a/src/membrain_seg/segmentation/cli/segment_cli.py
+++ b/src/membrain_seg/segmentation/cli/segment_cli.py
@@ -1,5 +1,13 @@
+import os
+
 from typer import Option
 
+from membrain_seg.segmentation.dataloading.data_utils import (
+    load_tomogram,
+    store_tomogram,
+)
+
+from ..connected_components import connected_components as _connected_components
 from ..segment import segment as _segment
 from .cli import OPTION_PROMPT_KWARGS as PKWARGS
 from .cli import cli
@@ -19,6 +27,14 @@ def segment(
     store_probabilities: bool = Option(  # noqa: B008
         False, help="Should probability maps be output in addition to segmentations?"
     ),
+    store_connected_components: bool = Option(  # noqa: B008
+        False, help="Should connected components of the segmentation be computed?"
+    ),
+    connected_component_thres: int = Option(  # noqa: B008
+        None,
+        help="Threshold for connected components. Components smaller than this will \
+            be removed from the segmentation.",
+    ),
     sliding_window_size: int = Option(  # noqa: B008
         160,
         help="Sliding window size used for inference. Smaller values than 160 \
@@ -32,11 +48,47 @@ def segment(
     membrain segment --tomogram-path <path-to-your-tomo>
     --ckpt-path <path-to-your-model>
     """
-    # Your segmenting logic here
     _segment(
         tomogram_path=tomogram_path,
         ckpt_path=ckpt_path,
         out_folder=out_folder,
         store_probabilities=store_probabilities,
+        store_connected_components=store_connected_components,
+        connected_component_thres=connected_component_thres,
         sw_roi_size=sliding_window_size,
     )
+
+
+@cli.command(name="components", no_args_is_help=True)
+def components(
+    segmentation_path: str = Option(  # noqa: B008
+        help="Path to the membrane segmentation to be processed.", **PKWARGS
+    ),
+    out_folder: str = Option(  # noqa: B008
+        "./predictions", help="Path to the folder where segmentations should be stored."
+    ),
+    connected_component_thres: int = Option(  # noqa: B008
+        None,
+        help="Threshold for connected components. Components smaller than this will \
+            be removed from the segmentation.",
+    ),
+):
+    """Compute connected components of your segmented tomogram.
+
+    This will annotate the connected components of your segmentation
+    with integer values from 1 to [number of membranes].
+
+    Example
+    -------
+    membrain components --tomogram-path <path-to-your-tomo>
+    --connected-component-thres 5
+    """
+    data, header = load_tomogram(segmentation_path, return_header=True)
+    conn_comps = _connected_components(
+        binary_seg=data, size_thres=connected_component_thres
+    )
+    out_file = os.path.join(
+        out_folder,
+        os.path.splitext(os.path.basename(segmentation_path))[0] + "_components.mrc",
+    )
+    store_tomogram(filename=out_file, tomogram=conn_comps, header=header)

--- a/src/membrain_seg/segmentation/connected_components.py
+++ b/src/membrain_seg/segmentation/connected_components.py
@@ -1,0 +1,47 @@
+import numpy as np
+from scipy import ndimage
+
+
+def connected_components(binary_seg: np.ndarray, size_thres: int = None):
+    """
+    Compute connected components from a 3D membrane segmentation.
+
+    The function uses 3D connectivity for label assignments. If a size
+    threshold is specified, components having size smaller than the
+    threshold will be removed.
+
+
+    Parameters
+    ----------
+    binary_seg : np.ndarray
+        Input 3D binary image with shape (X, Y, Z).
+        Non-zero elements are considered as the foreground.
+
+    size_thres : int, optional
+        The size threshold for removing small connected components.
+        Components having size (number of voxels) smaller than this
+        value will be removed.
+        If None (default), no components are removed.
+
+    Returns
+    -------
+    labeled_array : np.ndarray
+        A 3D image where each voxel in a connected component has a
+        unique label. The labels are in the range 1 to N, where N is
+        the number of connected components found. All background voxels
+        are zero.
+    """
+    print("Computing connected components.")
+    # Get 3D connected components
+    structure = np.ones((3, 3, 3))
+    labeled_array, num_features = ndimage.label(binary_seg, structure=structure)
+
+    # remove small clusters
+    if size_thres is not None:
+        print("Removing components smaller than", size_thres, "voxels.")
+        sizes = ndimage.sum(binary_seg, labeled_array, range(1, num_features + 1))
+        too_small = np.nonzero(sizes < size_thres)[0] + 1  # features labeled from 1
+        for feat_nr in too_small[::-1]:  # iterate in reverse order
+            labeled_array[labeled_array == feat_nr] = 0
+            labeled_array[labeled_array > feat_nr] -= 1
+    return labeled_array

--- a/src/membrain_seg/segmentation/connected_components.py
+++ b/src/membrain_seg/segmentation/connected_components.py
@@ -38,7 +38,11 @@ def connected_components(binary_seg: np.ndarray, size_thres: int = None):
 
     # remove small clusters
     if size_thres is not None:
-        print("Removing components smaller than", size_thres, "voxels.")
+        print(
+            "Removing components smaller than",
+            size_thres,
+            "voxels. (This can take a while)",
+        )
         sizes = ndimage.sum(binary_seg, labeled_array, range(1, num_features + 1))
         too_small = np.nonzero(sizes < size_thres)[0] + 1  # features labeled from 1
         for feat_nr in too_small[::-1]:  # iterate in reverse order

--- a/src/membrain_seg/segmentation/segment.py
+++ b/src/membrain_seg/segmentation/segment.py
@@ -13,7 +13,13 @@ from .dataloading.memseg_augmentation import get_mirrored_img, get_prediction_tr
 
 
 def segment(
-    tomogram_path, ckpt_path, out_folder, store_probabilities=False, sw_roi_size=160
+    tomogram_path,
+    ckpt_path,
+    out_folder,
+    store_probabilities=False,
+    sw_roi_size=160,
+    store_connected_components=False,
+    connected_component_thres=None,
 ):
     """
     Segment tomograms using a trained model.
@@ -39,6 +45,12 @@ def segment(
         Sliding window size used for inference. Smaller values than 160 consume less
         GPU, but also lead to worse segmentation results!
         Must be a multiple of 32.
+    store_connected_components: bool, optional
+        If True, connected components are computed and stored instead of the raw
+        segmentation.
+    connected_component_thres: int, optional
+        If specified, all connected components smaller than this threshold
+        are removed from the segmentation.
 
     Returns
     -------
@@ -102,7 +114,6 @@ def segment(
                     .detach()
                     .cpu()
                 )
-
     predictions /= 8.0
 
     # Extract segmentations and store them in an output file.
@@ -112,5 +123,7 @@ def segment(
         orig_data_path=new_data_path,
         ckpt_token=ckpt_token,
         store_probabilities=store_probabilities,
+        store_connected_components=store_connected_components,
+        connected_component_thres=connected_component_thres,
         mrc_header=mrc_header,
     )

--- a/src/membrain_seg/tomo_preprocessing/amplitude_spectrum_matching/_cli.py
+++ b/src/membrain_seg/tomo_preprocessing/amplitude_spectrum_matching/_cli.py
@@ -19,7 +19,7 @@ def extract(
 ):
     """Extracts the radially averaged amplitude spectrum from the input tomogram."""
     # Call your function here
-    input_tomo = load_tomogram(input_path)
+    input_tomo = load_tomogram(input_path).data
     _extract_spectrum(input_tomo, output_path)
 
 

--- a/src/membrain_seg/tomo_preprocessing/amplitude_spectrum_matching/match_spectrum.py
+++ b/src/membrain_seg/tomo_preprocessing/amplitude_spectrum_matching/match_spectrum.py
@@ -101,7 +101,7 @@ def match_amplitude_spectrum_for_files(
 
     # Match the amplitude spectrum of the input tomogram to the target spectrum
     filtered_tomo = match_spectrum(
-        tomo,
+        tomo.data,
         target_spectrum,
         cutoff,
         smoothen,
@@ -109,5 +109,6 @@ def match_amplitude_spectrum_for_files(
         shrink_excessive_value,
     )
     filtered_tomo = normalize_tomogram(filtered_tomo)
+    tomo.data = filtered_tomo
     # Save the filtered tomogram to a file
-    store_tomogram(output_path, filtered_tomo)
+    store_tomogram(output_path, tomo)

--- a/src/membrain_seg/tomo_preprocessing/pixel_size_matching/match_pixel_size_seg.py
+++ b/src/membrain_seg/tomo_preprocessing/pixel_size_matching/match_pixel_size_seg.py
@@ -48,18 +48,18 @@ def match_segmentation_pixel_size_to_tomo(
     """
     # Load the input tomogram and its pixel size
     file_path = seg_path
-    data = load_tomogram(file_path, normalize_data=False)
+    tomo = load_tomogram(file_path, normalize_data=False)
 
     # Get output shape from original tomogram
     match_tomo_path = orig_tomo_path
     orig_tomo = load_tomogram(match_tomo_path, normalize_data=False)
-    output_shape = orig_tomo.shape
+    output_shape = orig_tomo.data.shape
 
     print(
         "Matching input tomogram",
         os.path.basename(file_path),
         "from shape",
-        data.shape,
+        tomo.data.shape,
         "to shape",
         output_shape,
         ".",
@@ -67,9 +67,8 @@ def match_segmentation_pixel_size_to_tomo(
 
     rescale_factors = [
         target_dim / original_dim
-        for target_dim, original_dim in zip(output_shape, data.shape)
+        for target_dim, original_dim in zip(output_shape, tomo.data.shape)
     ]
-    resized_data = ndimage.zoom(data, rescale_factors, order=0, prefilter=False)
-
-    # Save the resized tomogram to the specified output path
-    store_tomogram(output_path, resized_data)
+    resized_data = ndimage.zoom(tomo.data, rescale_factors, order=0, prefilter=False)
+    orig_tomo.data = resized_data  # Keep the header of the original data
+    store_tomogram(output_path, orig_tomo)


### PR DESCRIPTION
This PR is about two things:
1. Added functionality to compute **connected components of output segmentation**. This will assign different labels to different components to differentiate between different membranes. Also, it is useful to use this in combination with ColabSeg, which recommends connected components as inputs.
2. Dataloading: As suggested in https://github.com/teamtomo/membrain-seg/issues/23 and https://github.com/teamtomo/membrain-seg/pull/22#pullrequestreview-1542271416 , I adjusted the dataloading: First, **tomogram loading does not depend on flags** whether to return a header anymore, but instead returns a Tomogram object which always contains data, header and voxel size. Second, I adjusted the **data storing to be more efficient.** Depending on the tomogram data type, it will try to find the most efficient .mrc file mode to store the data in. Thus, particularly segmentations can be stored much more efficiently (e.g. 2GB to 500MB). That's still way too much, but the best we can do with the mrc file format I think.