### PR TITLE
Adjust compatibility for ColabSeg

### DIFF
--- a/src/membrain_seg/segmentation/connected_components.py
+++ b/src/membrain_seg/segmentation/connected_components.py
@@ -37,7 +37,7 @@ def connected_components(binary_seg: np.ndarray, size_thres: int = None):
     labeled_array, num_features = ndimage.label(binary_seg, structure=structure)
 
     # remove small clusters
-    if size_thres is not None:
+    if size_thres is not None and size_thres > 1:
         print(
             "Removing components smaller than",
             size_thres,

--- a/src/membrain_seg/segmentation/dataloading/data_utils.py
+++ b/src/membrain_seg/segmentation/dataloading/data_utils.py
@@ -184,6 +184,7 @@ def store_segmented_tomograms(
     out_tomo = Tomogram(data=predictions_np_thres, header=mrc_header)
     store_tomogram(out_file_thres, out_tomo)
     print("MemBrain has finished segmenting your tomogram.")
+    return out_file_thres
 
 
 def read_nifti(nifti_file: str) -> np.ndarray:


### PR DESCRIPTION
Making a couple of adjustments to enable compatibility with ColabSeg, particularly
- return of output filename
- flag for activating test time augmentation (may not be wanted when running segmentation in jupyter notebook)