### PR TITLE
On the fly rescaling (GPU)

### DIFF
--- a/src/membrain_seg/segmentation/cli/cli.py
+++ b/src/membrain_seg/segmentation/cli/cli.py
@@ -18,6 +18,7 @@ cli = typer.Typer(
     add_completion=False,
     no_args_is_help=True,
     rich_markup_mode="rich",
+    pretty_exceptions_show_locals=False
 )
 OPTION_PROMPT_KWARGS = {"prompt": True, "prompt_required": True}
 PKWARGS = OPTION_PROMPT_KWARGS

--- a/src/membrain_seg/segmentation/cli/segment_cli.py
+++ b/src/membrain_seg/segmentation/cli/segment_cli.py
@@ -27,6 +27,9 @@ def segment(
     out_folder: str = Option(  # noqa: B008
         "./predictions", help="Path to the folder where segmentations should be stored."
     ),
+    rescale_patches: bool = Option( # noqa: B008
+        False, help="Should patches be rescaled on-the-fly during inference?"
+    ),
     in_pixel_size: float = Option(  # noqa: B008
         None,
         help="Pixel size of the input tomogram in Angstrom. \
@@ -76,6 +79,7 @@ def segment(
         tomogram_path=tomogram_path,
         ckpt_path=ckpt_path,
         out_folder=out_folder,
+        rescale_patches=rescale_patches,
         in_pixel_size=in_pixel_size,
         out_pixel_size=out_pixel_size,
         store_probabilities=store_probabilities,

--- a/src/membrain_seg/segmentation/cli/segment_cli.py
+++ b/src/membrain_seg/segmentation/cli/segment_cli.py
@@ -27,6 +27,16 @@ def segment(
     out_folder: str = Option(  # noqa: B008
         "./predictions", help="Path to the folder where segmentations should be stored."
     ),
+    in_pixel_size: float = Option(  # noqa: B008
+        10.,
+        help="Pixel size of the input tomogram in Angstrom. \
+            (default: 10 Angstrom)",
+    ),
+    out_pixel_size: float = Option(  # noqa: B008
+        10.,
+        help="Pixel size of the output segmentation in Angstrom. \
+            (default: 10 Angstrom; should normally stay at 10 Angstrom)",
+    ),
     store_probabilities: bool = Option(  # noqa: B008
         False, help="Should probability maps be output in addition to segmentations?"
     ),
@@ -66,6 +76,8 @@ def segment(
         tomogram_path=tomogram_path,
         ckpt_path=ckpt_path,
         out_folder=out_folder,
+        in_pixel_size=in_pixel_size,
+        out_pixel_size=out_pixel_size,
         store_probabilities=store_probabilities,
         store_connected_components=store_connected_components,
         connected_component_thres=connected_component_thres,

--- a/src/membrain_seg/segmentation/cli/segment_cli.py
+++ b/src/membrain_seg/segmentation/cli/segment_cli.py
@@ -28,7 +28,7 @@ def segment(
         "./predictions", help="Path to the folder where segmentations should be stored."
     ),
     in_pixel_size: float = Option(  # noqa: B008
-        10.,
+        None,
         help="Pixel size of the input tomogram in Angstrom. \
             (default: 10 Angstrom)",
     ),

--- a/src/membrain_seg/segmentation/networks/inference_unet.py
+++ b/src/membrain_seg/segmentation/networks/inference_unet.py
@@ -31,8 +31,8 @@ def rescale_tensor(
     torch.Tensor
         The rescaled tensor.
     """
-    # Ensure the sample is on the GPU
-    sample = sample.to("cuda").unsqueeze(0).unsqueeze(0)
+    # Add batch and channel dimensions
+    sample = sample.unsqueeze(0).unsqueeze(0)
 
     # Apply interpolation
     rescaled_sample = F.interpolate(
@@ -71,7 +71,7 @@ class PreprocessedSemanticSegmentationUnet(SemanticSegmentationUnet):
         """
         rescaled_samples = []
         for sample in x:
-            sample = sample[0]  # only take the first channel
+            sample = sample[0]  # only use the first channel
             if self.rescale_patches:
                 if sample.shape[0] > self.target_shape[0]:
                     sample = fourier_cropping_torch(sample, self.target_shape)
@@ -88,7 +88,7 @@ class PreprocessedSemanticSegmentationUnet(SemanticSegmentationUnet):
         """
         rescaled_samples = []
         for sample in x:
-            sample = sample[0]
+            sample = sample[0]  # only use first channel
             if self.rescale_patches:
                 sample = rescale_tensor(sample, orig_shape, mode="trilinear")
             rescaled_samples.append(sample.unsqueeze(0))

--- a/src/membrain_seg/segmentation/networks/inference_unet.py
+++ b/src/membrain_seg/segmentation/networks/inference_unet.py
@@ -1,19 +1,61 @@
 from typing import Tuple
 
+import torch
+import torch.nn.functional as F
+
 from membrain_seg.segmentation.networks.unet import SemanticSegmentationUnet
 from membrain_seg.tomo_preprocessing.matching_utils.px_matching_utils import (
-    fourier_cropping,
-    fourier_extend,
+    fourier_cropping_torch,
+    fourier_extend_torch,
 )
 
-from scipy import ndimage
-import torch
+
+def rescale_tensor(
+    sample: torch.Tensor, target_size: tuple, mode="trilinear"
+) -> torch.Tensor:
+    """
+    Rescales the input tensor by given factors using interpolation.
+
+    Parameters
+    ----------
+    sample : torch.Tensor
+        The input data as a torch tensor.
+    target_size : tuple
+        The target size of the rescaled tensor.
+    mode : str, optional
+        The mode of interpolation ('nearest', 'linear', 'bilinear',
+          'bicubic', or 'trilinear'). Default is 'trilinear'.
+
+    Returns
+    -------
+    torch.Tensor
+        The rescaled tensor.
+    """
+    # Ensure the sample is on the GPU
+    sample = sample.to("cuda").unsqueeze(0).unsqueeze(0)
+
+    # Apply interpolation
+    rescaled_sample = F.interpolate(
+        sample, size=target_size, mode=mode, align_corners=False
+    )
+
+    return rescaled_sample.squeeze(0).squeeze(0)
+
 
 class PreprocessedSemanticSegmentationUnet(SemanticSegmentationUnet):
+    """U-Net with rescaling preprocessing.
+
+    This class extends the SemanticSegmentationUnet class by adding
+    preprocessing and postprocessing steps. The preprocessing step
+    rescales the input to the target shape, and the postprocessing
+    step rescales the output to the original shape.
+    All of this is done on the GPU if available.
+    """
+
     def __init__(
         self,
         *args,
-        rescale_patches: bool = False, # Should patches be rescaled?
+        rescale_patches: bool = False,  # Should patches be rescaled?
         target_shape: Tuple[int, int, int] = (160, 160, 160),
         **kwargs,
     ):
@@ -21,38 +63,40 @@ class PreprocessedSemanticSegmentationUnet(SemanticSegmentationUnet):
         # Store the preprocessing parameters
         self.rescale_patches = rescale_patches
         self.target_shape = target_shape
-    
+
     def preprocess(self, x):
+        """Preprocess the input to the network.
+
+        In this case, we rescale the input to the target shape.
+        """
         rescaled_samples = []
         for sample in x:
+            sample = sample[0]  # only take the first channel
             if self.rescale_patches:
-                sample = sample.numpy()[0]
                 if sample.shape[0] > self.target_shape[0]:
-                    sample = fourier_cropping(sample, self.target_shape, smoothing=False)
+                    sample = fourier_cropping_torch(sample, self.target_shape)
                 elif sample.shape[0] < self.target_shape[0]:
-                    sample = fourier_extend(sample, self.target_shape, smoothing=False)
-                sample = torch.from_numpy(sample)
+                    sample = fourier_extend_torch(sample, self.target_shape)
             rescaled_samples.append(sample.unsqueeze(0))
         rescaled_samples = torch.stack(rescaled_samples, dim=0)
         return rescaled_samples
 
     def postprocess(self, x, orig_shape):
-        cur_shape = x.shape[2:]
-        rescale_factors = [
-            target_dim / original_dim
-            for target_dim, original_dim in zip(orig_shape, cur_shape)
-        ]
+        """Postprocess the output of the network.
+
+        In this case, we rescale the output to the original shape.
+        """
         rescaled_samples = []
         for sample in x:
+            sample = sample[0]
             if self.rescale_patches:
-                sample = sample.numpy()[0]
-                sample = ndimage.zoom(sample, rescale_factors, order=0, prefilter=False)
-                sample = torch.from_numpy(sample)
-                rescaled_samples.append(sample.unsqueeze(0))
+                sample = rescale_tensor(sample, orig_shape, mode="trilinear")
+            rescaled_samples.append(sample.unsqueeze(0))
         rescaled_samples = torch.stack(rescaled_samples, dim=0)
         return rescaled_samples
 
     def forward(self, x):
+        """Forward pass through the network."""
         orig_shape = x.shape[2:]
         preprocessed_x = self.preprocess(x)
         predicted = super().forward(preprocessed_x)

--- a/src/membrain_seg/segmentation/networks/inference_unet.py
+++ b/src/membrain_seg/segmentation/networks/inference_unet.py
@@ -30,9 +30,7 @@ class PreprocessedSemanticSegmentationUnet(SemanticSegmentationUnet):
                 if sample.shape[0] > self.target_shape[0]:
                     sample = fourier_cropping(sample, self.target_shape, smoothing=False)
                 elif sample.shape[0] < self.target_shape[0]:
-                    print("Entering")
                     sample = fourier_extend(sample, self.target_shape, smoothing=False)
-                    print("Exiting")
                 sample = torch.from_numpy(sample)
             rescaled_samples.append(sample.unsqueeze(0))
         rescaled_samples = torch.stack(rescaled_samples, dim=0)

--- a/src/membrain_seg/segmentation/networks/inference_unet.py
+++ b/src/membrain_seg/segmentation/networks/inference_unet.py
@@ -1,0 +1,63 @@
+from typing import Tuple
+
+from membrain_seg.segmentation.networks.unet import SemanticSegmentationUnet
+from membrain_seg.tomo_preprocessing.matching_utils.px_matching_utils import (
+    fourier_cropping,
+    fourier_extend,
+)
+
+from scipy import ndimage
+import torch
+
+class PreprocessedSemanticSegmentationUnet(SemanticSegmentationUnet):
+    def __init__(
+        self,
+        *args,
+        rescale_patches: bool = False, # Should patches be rescaled?
+        target_shape: Tuple[int, int, int] = (160, 160, 160),
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        # Store the preprocessing parameters
+        self.rescale_patches = rescale_patches
+        self.target_shape = target_shape
+    
+    def preprocess(self, x):
+        rescaled_samples = []
+        for sample in x:
+            if self.rescale_patches:
+                sample = sample.numpy()[0]
+                if sample.shape[0] > self.target_shape[0]:
+                    sample = fourier_cropping(sample, self.target_shape, smoothing=False)
+                elif sample.shape[0] < self.target_shape[0]:
+                    print("Entering")
+                    sample = fourier_extend(sample, self.target_shape, smoothing=False)
+                    print("Exiting")
+                sample = torch.from_numpy(sample)
+            rescaled_samples.append(sample.unsqueeze(0))
+        rescaled_samples = torch.stack(rescaled_samples, dim=0)
+        return rescaled_samples
+
+    def postprocess(self, x, orig_shape):
+        cur_shape = x.shape[2:]
+        rescale_factors = [
+            target_dim / original_dim
+            for target_dim, original_dim in zip(orig_shape, cur_shape)
+        ]
+        rescaled_samples = []
+        for sample in x:
+            if self.rescale_patches:
+                sample = sample.numpy()[0]
+                sample = ndimage.zoom(sample, rescale_factors, order=0, prefilter=False)
+                sample = torch.from_numpy(sample)
+                rescaled_samples.append(sample.unsqueeze(0))
+        rescaled_samples = torch.stack(rescaled_samples, dim=0)
+        return rescaled_samples
+
+    def forward(self, x):
+        orig_shape = x.shape[2:]
+        preprocessed_x = self.preprocess(x)
+        predicted = super().forward(preprocessed_x)
+        postprocessed_predicted = self.postprocess(predicted[0], orig_shape)
+        # Return list to be compatible with deep supervision outputs
+        return [postprocessed_predicted]

--- a/src/membrain_seg/segmentation/networks/inference_unet.py
+++ b/src/membrain_seg/segmentation/networks/inference_unet.py
@@ -74,9 +74,13 @@ class PreprocessedSemanticSegmentationUnet(SemanticSegmentationUnet):
             sample = sample[0]  # only use the first channel
             if self.rescale_patches:
                 if sample.shape[0] > self.target_shape[0]:
-                    sample = fourier_cropping_torch(sample, self.target_shape)
+                    sample = fourier_cropping_torch(
+                        data=sample, new_shape=self.target_shape, device=self.device
+                    )
                 elif sample.shape[0] < self.target_shape[0]:
-                    sample = fourier_extend_torch(sample, self.target_shape)
+                    sample = fourier_extend_torch(
+                        data=sample, new_shape=self.target_shape, device=self.device
+                    )
             rescaled_samples.append(sample.unsqueeze(0))
         rescaled_samples = torch.stack(rescaled_samples, dim=0)
         return rescaled_samples

--- a/src/membrain_seg/segmentation/segment.py
+++ b/src/membrain_seg/segmentation/segment.py
@@ -106,7 +106,9 @@ def segment(
     if rescale_patches:
         # Rescale patches if necessary
         if in_pixel_size is None:
-            in_pixel_size = voxel_size
+            in_pixel_size = voxel_size.x
+        if in_pixel_size == 0.0:
+            raise ValueError("Input pixel size is 0.0. Please specify the pixel size manually.")
         if in_pixel_size == 1.0:
             print("WARNING: Input pixel size is 1.0. Looks like a corrupt header. Please specify the pixel size manually.")
         pl_model.rescale_patches = in_pixel_size != out_pixel_size
@@ -136,7 +138,8 @@ def segment(
 
     # Perform test time augmentation (8-fold mirroring)
     predictions = torch.zeros_like(new_data)
-    print("Performing 8-fold test-time augmentation.")
+    if test_time_augmentation:
+        print("Performing 8-fold test-time augmentation. I.e. the following bar will run 8 times.")
     for m in range(8 if test_time_augmentation else 1):
         with torch.no_grad():
             with torch.cuda.amp.autocast():

--- a/src/membrain_seg/tomo_preprocessing/matching_utils/px_matching_utils.py
+++ b/src/membrain_seg/tomo_preprocessing/matching_utils/px_matching_utils.py
@@ -7,7 +7,9 @@ from scipy.fft import fftn, ifftn
 from scipy.ndimage import distance_transform_edt
 
 
-def fourier_cropping_torch(data: torch.Tensor, new_shape: tuple) -> torch.Tensor:
+def fourier_cropping_torch(
+    data: torch.Tensor, new_shape: tuple, device: torch.device = None
+) -> torch.Tensor:
     """
     Fourier cropping adapted for PyTorch and GPU, without smoothing functionality.
 
@@ -17,13 +19,18 @@ def fourier_cropping_torch(data: torch.Tensor, new_shape: tuple) -> torch.Tensor
         The input data as a 3D torch tensor on GPU.
     new_shape : tuple
         The target shape for the cropped data as a tuple (x, y, z).
+    device : torch.device, optional
+        The device to use for the computation. If None, the device is set to "cuda" if
+        available; otherwise, it is set to "cpu".
 
     Returns
     -------
     torch.Tensor
         The resized data as a 3D torch tensor.
     """
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device is None:
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+
     data = data.to(device)
 
     # Calculate the FFT of the input data
@@ -51,7 +58,9 @@ def fourier_cropping_torch(data: torch.Tensor, new_shape: tuple) -> torch.Tensor
     return resized_data
 
 
-def fourier_extend_torch(data: torch.Tensor, new_shape: tuple) -> torch.Tensor:
+def fourier_extend_torch(
+    data: torch.Tensor, new_shape: tuple, device: torch.device = None
+) -> torch.Tensor:
     """
     Fourier padding adapted for PyTorch and GPU, without smoothing functionality.
 
@@ -61,13 +70,18 @@ def fourier_extend_torch(data: torch.Tensor, new_shape: tuple) -> torch.Tensor:
         The input data as a 3D torch tensor on GPU.
     new_shape : tuple
         The target shape for the extended data as a tuple (x, y, z).
+    device : torch.device, optional
+        The device to use for the computation. If None, the device is set to "cuda" if
+        available; otherwise, it is set to "cpu".
 
     Returns
     -------
     torch.Tensor
         The resized data as a 3D torch tensor.
     """
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device is None:
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+
     data = data.to(device)
 
     data_fft = torch.fft.fftn(data)


### PR DESCRIPTION
Regarding the discussion in https://github.com/teamtomo/membrain-seg/issues/55, I added the option to perform rescaling of the inference patches on the fly and on GPU.

With this, the user can simply input tomograms in any pixel size, the model will perform sliding window inference, and rescale each patch individually to e.g. 10A. The output is again a segmentation in the original pixel size.

This is really fast (difference depending on tomo pixel size, but e.g. 150 vs 155sec inference time) and did not result in big changes in segmentation quality.

How it's done internally:
1. Sliding Window inferer window size is adjusted s.t. after rescaling this sliding window (e.g. to 10A), the rescaled window has the target size (default 160)
2. Rescaling is performed within the model itself (as preprocessing / postprocessing options). This way, we do not need to touch the SWInferer class, which seemed convenient to me.
Workflow: rescale patch to 160^3 --> model prediction --> rescale back to original shape
3. The SWInferer stitches together the patches in the original dimensions 

@alisterburt This is not using any libtilt functionality yet (I only found fourier cropping / padding for 2D, but I guess this could easily be extended). I guess the rescaling itself could be done more sophisticated, but but sure if necessary for this task?
@rdrighetto 

Happy for any feedback :)