### PR TITLE
fix numpy < 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,16 +25,17 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "monai",
-    "pytorch-lightning",
-    "torch",
     "imageio",
-    "scipy",
-    "typer[all]",
-    "scikit-image",
-    "simpleitk",
-    "pandas",
     "mrcfile",
+    "monai",
+    "numpy<2.0.0",
+    "pandas",
+    "pytorch-lightning",
+    "scikit-image",
+    "scipy",
+    "simpleitk",
+    "torch",
+    "typer[all]",
 ]
 
 


### PR DESCRIPTION
Numpy 2.0.0 is causing some issues in some dependencies, e.g. MONAI.

This PR should fix issues https://github.com/teamtomo/membrain-seg/issues/70 and https://github.com/teamtomo/membrain-seg/issues/71