### PR TITLE
update docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To enhance segmentation, MemBrain-seg includes preprocessing functions. These he
 Explore MemBrain-seg, use it for your needs, and let us know how it works for you!
 
 
-Preliminary [documentation](https://teamtomo.org/membrain-seg/) is available, but far from perfect. Please let us know if you encounter any issues, and we are more than happy to help (and get feedback what does not work yet).
+Preliminary [documentation](https://teamtomo.github.io/membrain-seg/) is available, but far from perfect. Please let us know if you encounter any issues, and we are more than happy to help (and get feedback what does not work yet).
 
 ```
 [1] Lamm, L., Zufferey, S., Righetto, R.D., Wietrzynski, W., Yamauchi, K.A., Burt, A., Liu, Y., Zhang, H., Martinez-Sanchez, A., Ziegler, S., Isensee, F., Schnabel, J.A., Engel, B.D., and Peng, T, 2024. MemBrain v2: an end-to-end tool for the analysis of membranes in cryo-electron tomography. bioRxiv, https://doi.org/10.1101/2024.01.05.574336
@@ -51,12 +51,12 @@ Preliminary [documentation](https://teamtomo.org/membrain-seg/) is available, bu
 ```
 
 # Installation
-For detailed installation instructions, please look [here](https://teamtomo.org/membrain-seg/installation/).
+For detailed installation instructions, please look [here](https://teamtomo.github.io/membrain-seg/installation/).
 
 # Features
 ## Segmentation
 Segmenting the membranes in your tomograms is the main feature of this repository. 
-Please find more detailed instructions [here](https://teamtomo.org/membrain-seg/Usage/Segmentation/).
+Please find more detailed instructions [here](https://teamtomo.github.io/membrain-seg/Usage/Segmentation/).
 
 ## Preprocessing
 Currently, we provide the following two [preprocessing](https://github.com/teamtomo/membrain-seg/tree/main/src/membrain_seg/tomo_preprocessing) options:
@@ -64,12 +64,12 @@ Currently, we provide the following two [preprocessing](https://github.com/teamt
 - Fourier amplitude matching: Scale Fourier components to match the "style" of different tomograms
 - Deconvolution: denoises the tomogram by applying the deconvolution filter from Warp
 
-For more information, see the [Preprocessing](https://teamtomo.org/membrain-seg/Usage/Preprocessing/) subsection.
+For more information, see the [Preprocessing](https://teamtomo.github.io/membrain-seg/Usage/Preprocessing/) subsection.
 
 ## Model training
-It is also possible to use this package to train your own model. Instructions can be found [here](https://teamtomo.org/membrain-seg/Usage/Training/).
+It is also possible to use this package to train your own model. Instructions can be found [here](https://teamtomo.github.io/membrain-seg/Usage/Training/).
 
 ## Patch annotations
 In case you would like to train a model that works better for your tomograms, it may be beneficial to add some more patches from your tomograms to the training dataset. 
-Recommendations on how to to this can be found [here](https://teamtomo.org/membrain-seg/Usage/Annotations/).
+Recommendations on how to to this can be found [here](https://teamtomo.github.io/membrain-seg/Usage/Annotations/).
 

--- a/docs/Usage/Preprocessing.md
+++ b/docs/Usage/Preprocessing.md
@@ -27,7 +27,7 @@ This module currently allows you to use the following preprocessing methods:
 We are still exploring when it makes sense to use which preprocessing technique. But here are 
 already some rules of thumb:
 
-1. Whenever your pixel sizes differs by a lot from around 10-12&Aring; / pixel, you should consider using pixel size matching. We recommend to match to a pixel size of 10&Aring;. <br> It is also possible to do this rescaling on-the-fly, see our [segmentation instructions](https://teamtomo.org/membrain-seg/Usage/Segmentation/#on-the-fly-rescaling).
+1. Whenever your pixel sizes differs by a lot from around 10-12&Aring; / pixel, you should consider using pixel size matching. We recommend to match to a pixel size of 10&Aring;. <br> It is also possible to do this rescaling on-the-fly, see our [segmentation instructions](https://teamtomo.github.io/membrain-seg/Usage/Segmentation/#on-the-fly-rescaling).
 2. The Fourier amplitude matching only works in some cases, depending on the CTFs of input 
 and target tomograms. Our current recommendation is: If you're not satisfied with MemBrain's 
 segmentation performance, why not give the amplitude matching a shot?
@@ -74,7 +74,7 @@ tomo_preprocessing deconvolve --input <path-to-tomo> --output <path-to-output> -
 
 ### **Pixel Size Matching**
 Pixel size matching is recommended when your tomogram pixel sizes differs strongly from the training pixel size range (roughly 10-14&Aring;). <br>
-**IMPORTANT NOTE**: MemBrain-seg can now also perform the rescaling on-the-fly during segmentation, making the below worklow redundant if you are not interested in the rescaled tomograms. You can check the on-the-fly rescaling at our [segmentation instructions](https://teamtomo.org/membrain-seg/Usage/Segmentation/#on-the-fly-rescaling)
+**IMPORTANT NOTE**: MemBrain-seg can now also perform the rescaling on-the-fly during segmentation, making the below worklow redundant if you are not interested in the rescaled tomograms. You can check the on-the-fly rescaling at our [segmentation instructions](https://teamtomo.github.io/membrain-seg/Usage/Segmentation/#on-the-fly-rescaling)
 
 If you prefer to not do it on-the-fly, you can perform the pixel size matching using the command
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ To enhance segmentation, MemBrain-seg includes preprocessing functions. These he
 Explore MemBrain-seg, use it for your needs, and let us know how it works for you!
 
 
-Preliminary [documentation](https://teamtomo.org/membrain-seg/) is available, but far from perfect. Please let us know if you encounter any issues, and we are more than happy to help (and get feedback what does not work yet).
+Preliminary [documentation](https://teamtomo.github.io/membrain-seg/) is available, but far from perfect. Please let us know if you encounter any issues, and we are more than happy to help (and get feedback what does not work yet).
 
 ```
 [1] Lamm, L., Zufferey, S., Righetto, R.D., Wietrzynski, W., Yamauchi, K.A., Burt, A., Liu, Y., Zhang, H., Martinez-Sanchez, A., Ziegler, S., Isensee, F., Schnabel, J.A., Engel, B.D., and Peng, T, 2024. MemBrain v2: an end-to-end tool for the analysis of membranes in cryo-electron tomography. bioRxiv, https://doi.org/10.1101/2024.01.05.574336
@@ -26,12 +26,12 @@ Preliminary [documentation](https://teamtomo.org/membrain-seg/) is available, bu
 ```
 
 # Installation
-For detailed installation instructions, please look [here](https://teamtomo.org/membrain-seg/installation/).
+For detailed installation instructions, please look [here](https://teamtomo.github.io/membrain-seg/installation/).
 
 # Features
 ## Segmentation
 Segmenting the membranes in your tomograms is the main feature of this repository. 
-Please find more detailed instructions [here](https://teamtomo.org/membrain-seg/Usage/Segmentation/).
+Please find more detailed instructions [here](https://teamtomo.github.io/membrain-seg/Usage/Segmentation/).
 
 ## Preprocessing
 Currently, we provide the following two [preprocessing](https://github.com/teamtomo/membrain-seg/tree/main/src/membrain_seg/tomo_preprocessing) options:
@@ -39,11 +39,11 @@ Currently, we provide the following two [preprocessing](https://github.com/teamt
 - Fourier amplitude matching: Scale Fourier components to match the "style" of different tomograms
 - Deconvolution: denoises the tomogram by applying the deconvolution filter from Warp
 
-For more information, see the [Preprocessing](https://teamtomo.org/membrain-seg/Usage/Preprocessing/) subsection.
+For more information, see the [Preprocessing](https://teamtomo.github.io/membrain-seg/Usage/Preprocessing/) subsection.
 
 ## Model training
-It is also possible to use this package to train your own model. Instructions can be found [here](https://teamtomo.org/membrain-seg/Usage/Training/).
+It is also possible to use this package to train your own model. Instructions can be found [here](https://teamtomo.github.io/membrain-seg/Usage/Training/).
 
 ## Patch annotations
 In case you would like to train a model that works better for your tomograms, it may be beneficial to add some more patches from your tomograms to the training dataset. 
-Recommendations on how to to this can be found [here](https://teamtomo.org/membrain-seg/Usage/Annotations/).
+Recommendations on how to to this can be found [here](https://teamtomo.github.io/membrain-seg/Usage/Annotations/).


### PR DESCRIPTION
This PR updates the docs links from teamtomo.org to teamtomo.github.io

Previously, docs were not available anymore as pointed out in https://github.com/teamtomo/membrain-seg/issues/78
