### PR TITLE
enable cpu device for skeletonization

### DIFF
--- a/src/membrain_seg/segmentation/cli/ske_cli.py
+++ b/src/membrain_seg/segmentation/cli/ske_cli.py
@@ -22,6 +22,11 @@ def skeletonize(
         "the entire volume is processed at once. If operating with limited GPU "
         "resources, a batch size of 1,000,000 is recommended.",
     ),
+    device: str = Option(  # noqa: B008
+        None,
+        help="Device to use for processing. If not specified, the default device "
+        "will be used. Options are 'cpu' or 'cuda'.",
+    ),
 ):
     """
     Perform skeletonization on labeled tomograms using nonmax-suppression technique.
@@ -72,7 +77,7 @@ def skeletonize(
     print("")
 
     segmentation = load_tomogram(label_path)
-    ske = _skeletonization(segmentation=segmentation.data, batch_size=batch_size)
+    ske = _skeletonization(segmentation=segmentation.data, batch_size=batch_size, device=device)
 
     # Update the segmentation data with the skeletonized output while preserving the
     # original header and voxel_size

--- a/src/membrain_seg/segmentation/skeletonize.py
+++ b/src/membrain_seg/segmentation/skeletonize.py
@@ -25,7 +25,7 @@ from membrain_seg.segmentation.skeletonization.nonmaxsup import nonmaxsup
 from membrain_seg.segmentation.training.surface_dice import apply_gaussian_filter
 
 
-def skeletonization(segmentation: np.ndarray, batch_size: int) -> np.ndarray:
+def skeletonization(segmentation: np.ndarray, batch_size: int, device: str=None) -> np.ndarray:
     """
     Perform skeletonization on a tomogram segmentation.
 
@@ -78,7 +78,11 @@ def skeletonization(segmentation: np.ndarray, batch_size: int) -> np.ndarray:
 
     # Apply Gaussian filter with the same sigma value for all dimensions
     # Load hessian tensors on GPU
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if device is None:
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    else:
+        assert device in ["cuda", "cpu"], "Device must be either 'cuda' or 'cpu'."
+        device = torch.device(device)
 
     filtered_hessian = [
         apply_gaussian_filter(


### PR DESCRIPTION
As pointed out in https://github.com/teamtomo/membrain-seg/issues/97, skeletonization can run into CUDA issues. This PR enables to simply use the CPU for all calculations by specifying "--device cpu" in the CLI.