### PR TITLE
rescale spectra by padding and cropping

### DIFF
--- a/src/membrain_seg/tomo_preprocessing/matching_utils/spec_matching_utils.py
+++ b/src/membrain_seg/tomo_preprocessing/matching_utils/spec_matching_utils.py
@@ -149,7 +149,13 @@ def match_spectrum(
     input_spectrum = radial_average(np.abs(t))
 
     # Resize the target spectrum to match the input spectrum's length
-    target_spectrum = np.resize(target_spectrum, len(input_spectrum))
+    if len(target_spectrum) > len(input_spectrum):
+        target_spectrum = target_spectrum[: len(input_spectrum)]
+    elif len(target_spectrum) < len(input_spectrum):
+        target_spectrum = np.pad(
+            target_spectrum, (0, len(input_spectrum) - len(target_spectrum)), "edge"
+        )
+
 
     almost_zeros_input = np.argwhere(input_spectrum < 1e-1)
     almost_zeros_target = np.argwhere(target_spectrum < 1e-4)


### PR DESCRIPTION
As pointed out in https://github.com/teamtomo/membrain-seg/issues/98, resizing of amplitude spectra was performed with numpy.resize, which, instead of zero-padding, repeats values, causing artifacts in the tomograms.

Now changed to truncating / zero-padding the array.