### PR TITLE
fix: pad annotations with the ignore label (2)

### DIFF
--- a/src/membrain_seg/segmentation/dataloading/memseg_dataset.py
+++ b/src/membrain_seg/segmentation/dataloading/memseg_dataset.py
@@ -197,7 +197,7 @@ class CryoETMemSegDataset(Dataset):
                         (0, max(self.patch_size - img.shape[3], 0)),
                     ),
                     mode="constant",
-                    constant_values=2,
+                    constant_values=0,
                 )
                 label = np.pad(
                     label,
@@ -208,7 +208,7 @@ class CryoETMemSegDataset(Dataset):
                         (0, max(self.patch_size - label.shape[3], 0)),
                     ),
                     mode="constant",
-                    constant_values=0,
+                    constant_values=2,
                 )
             assert (
                 img.shape[1] == self.patch_size


### PR DESCRIPTION
[WHAT]
Fix padding issue in the dataset class

[WHY]
The tomos were wrongly padded with 2s, while annotations were wrongly padded with 0s