### PR TITLE
remove smaller 2 requirement for numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "imageio",
     "mrcfile",
     "monai",
-    "numpy<2.0.0",
+    "numpy",
     "pandas",
     "pytorch-lightning",
     "scikit-image",


### PR DESCRIPTION
This removes the requirement for numpy to be smaller than 2.0.
Initially, we had this requirement because MONAI's dependencies had issues with the new numpy version, but these limitations are not necessary anymore.

Solves the issue raised in https://github.com/teamtomo/membrain-seg/issues/107 